### PR TITLE
feat: working solution for abort-controler

### DIFF
--- a/examples/module1/lesson4/abort-feedback/App.tsx
+++ b/examples/module1/lesson4/abort-feedback/App.tsx
@@ -1,35 +1,23 @@
-import { useEffect, useState } from 'react';
-
-interface User {
-  id: number;
-  name: string;
-}
-
-const API_URL = '/api/data/users?timeout=10000';
+import { useUsers } from './hooks/useUsers';
 
 const App = () => {
-  const [users, setUsers] = useState<User[]>([]);
-
-  useEffect(() => {
-    fetch(API_URL)
-      .then((res) => res.json())
-      .then(({ users }) => {
-        setUsers(users);
-      });
-  }, []);
+  const { fetchUsers, users, error } = useUsers();
 
   return (
     <div>
       <div className="flex flex-row items-center justify-between py-4">
         <h1 className="text-2xl font-bold">Users</h1>
-        <div className="flex flex-row items-center">
-          <p className="mr-2">
-            Sorry, there seems to be connectivity issues...
-          </p>
-          <button className="text-blue-400 bg-blue-200 hover:text-blue-200 hover:bg-blue-400 rounded-md p-4">
-            Try again
-          </button>
-        </div>
+        {error ? (
+          <div className="flex flex-row items-center">
+            <p className="mr-2">{error}</p>
+            <button
+              onClick={fetchUsers}
+              className="text-blue-400 bg-blue-200 hover:text-blue-200 hover:bg-blue-400 rounded-md p-4"
+            >
+              Try again
+            </button>
+          </div>
+        ) : null}
       </div>
       <ul className="space-y-2">
         {users.map((user, index) => (

--- a/examples/module1/lesson4/abort-feedback/hooks/useUsers.ts
+++ b/examples/module1/lesson4/abort-feedback/hooks/useUsers.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { User } from '../types/User';
+
+const ONE_SEC = 1000;
+
+const API_URL = '/api/data/users?timeout=10000';
+const CONNECT_ERROR_MSG = 'Sorry, there seems to be connectivity issues...';
+
+export const useUsers = () => {
+  const [error, setError] = useState<string | null>(null);
+  const [users, setUsers] = useState<User[]>([]);
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const fetchUsers = useCallback(async () => {
+    try {
+      setError(null);
+
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+
+      if (abortControllerRef.current) abortControllerRef.current.abort();
+      abortControllerRef.current = new AbortController();
+
+      timeoutRef.current = setTimeout(
+        () => setError(CONNECT_ERROR_MSG),
+        ONE_SEC * 4
+      );
+
+      const response = await fetch(API_URL, {
+        signal: abortControllerRef.current.signal,
+      });
+
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+
+      if (!response.ok) throw new Error('Failed to fetch. Please try again.');
+
+      const data = await response.json();
+      setUsers(data);
+      setError(null);
+
+      abortControllerRef.current = null;
+    } catch (err) {
+      console.error(err);
+
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+
+      if (err instanceof Error) setError(err.message);
+      else setError('Internal server error. Please try again.');
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (abortControllerRef.current) abortControllerRef.current.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  return { error, users, fetchUsers };
+};

--- a/examples/module1/lesson4/abort-feedback/types/User.ts
+++ b/examples/module1/lesson4/abort-feedback/types/User.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: number;
+  name: string;
+}


### PR DESCRIPTION
Kluczowe wnioski do zapamiętania

- Nie wiedziałem, że w zadaniu mogę użyć axiosa XD

- Race Condition  - przerywać poprzednie żądania oraz czyścić ich timeouty jednocześnie przy rozpoczynaniu nowego żądania.

- Kolejność wykonywania — obsłużyć fakt, że przy przerwaniu żądania blok catch nie wykonuje się natychmiast. Zabezpieczać się przed sytuacją, gdy stary timeout nadpisuje z nowego fetcha.

- Zawsze czyścić timeout przed przerywaniem żądania lub równocześnie z nim. Pamiętać, że samo przerwanie żądania nie zatrzymuje związanych z nim timeoutów.

- Używać useRef do przechowywania identyfikatorów timeoutów i kontrolerów przerwań, aby były dostępne między renderowaniami.

- Zawsze pamiętać o czyszczeniu timeoutów i przerwaniu żądań w funkcji czyszczącej useEffect.
